### PR TITLE
Add `visibility` flag to manifest

### DIFF
--- a/src/poser/napari.yaml
+++ b/src/poser/napari.yaml
@@ -1,5 +1,6 @@
 name: PoseR-napari
 display_name: PoseR
+visibility: hidden
 contributions:
   commands:
     - id: PoseR-napari.make_qwidget


### PR DESCRIPTION
Hello, I've opened this PR because you have `visibility: hidden` set in your napari hub config file. The napari core devs and napari hub team are in the process of updating the napari hub to use the visibility flag in the plugin manifest, so I've added this flag there as well.

The napari hub changes aren't released yet, but this will be a hard deprecation of the flag in its current location, so I've not yet removed it from `.napari-hub/config.yml`. Once changes to the napari hub are all released I'll make a follow up PR to remove the unused flag. 

Note that once we proceed with the deprecation, if you make a new release without this PR, your plugin will become visible on the napari hub.

Please let me know if you have any questions about this PR or if anything is unclear :blush: